### PR TITLE
Add support for long-live token

### DIFF
--- a/config/doctrine/ZfrOAuth2.Server.Entity.AccessToken.dcm.xml
+++ b/config/doctrine/ZfrOAuth2.Server.Entity.AccessToken.dcm.xml
@@ -6,5 +6,10 @@
     http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <entity name="ZfrOAuth2\Server\Entity\AccessToken" table="oauth_access_tokens" read-only="true">
+        <attribute-overrides>
+            <attribute-override name="expiresAt">
+                <field nullable="true" />
+            </attribute-override>
+        </attribute-overrides>
     </entity>
 </doctrine-mapping>

--- a/config/doctrine/ZfrOAuth2.Server.Entity.RefreshToken.dcm.xml
+++ b/config/doctrine/ZfrOAuth2.Server.Entity.RefreshToken.dcm.xml
@@ -6,5 +6,10 @@
     http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <entity name="ZfrOAuth2\Server\Entity\RefreshToken" table="oauth_refresh_tokens" read-only="true">
+        <attribute-overrides>
+            <attribute-override name="expiresAt">
+                <field nullable="true" />
+            </attribute-override>
+        </attribute-overrides>
     </entity>
 </doctrine-mapping>

--- a/src/ZfrOAuth2/Server/Entity/AccessToken.php
+++ b/src/ZfrOAuth2/Server/Entity/AccessToken.php
@@ -26,4 +26,11 @@ namespace ZfrOAuth2\Server\Entity;
  */
 class AccessToken extends AbstractToken
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function isExpired()
+    {
+        return parent::isExpired() && $this->expiresAt !== null;
+    }
 }

--- a/src/ZfrOAuth2/Server/Entity/RefreshToken.php
+++ b/src/ZfrOAuth2/Server/Entity/RefreshToken.php
@@ -26,4 +26,11 @@ namespace ZfrOAuth2\Server\Entity;
  */
 class RefreshToken extends AbstractToken
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function isExpired()
+    {
+        return parent::isExpired() && $this->expiresAt !== null;
+    }
 }

--- a/tests/ZfrOAuth2Test/Server/Entity/AccessTokenTest.php
+++ b/tests/ZfrOAuth2Test/Server/Entity/AccessTokenTest.php
@@ -97,4 +97,10 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($accessToken->isExpired());
     }
+
+    public function testSupportLongLiveToken()
+    {
+        $accessToken = new AccessToken();
+        $this->assertFalse($accessToken->isExpired());
+    }
 }

--- a/tests/ZfrOAuth2Test/Server/Entity/AuthorizationCodeTest.php
+++ b/tests/ZfrOAuth2Test/Server/Entity/AuthorizationCodeTest.php
@@ -99,4 +99,10 @@ class AuthorizationCodeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($authorizationCode->isExpired());
     }
+
+    public function testDoNotSupportLongLiveToken()
+    {
+        $accessToken = new AuthorizationCode();
+        $this->assertTrue($accessToken->isExpired());
+    }
 }

--- a/tests/ZfrOAuth2Test/Server/Entity/RefreshTokenTest.php
+++ b/tests/ZfrOAuth2Test/Server/Entity/RefreshTokenTest.php
@@ -97,4 +97,10 @@ class RefreshTokenTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($refreshToken->isExpired());
     }
+
+    public function testSupportLongLiveToken()
+    {
+        $accessToken = new RefreshToken();
+        $this->assertFalse($accessToken->isExpired());
+    }
 }


### PR DESCRIPTION
This PR adds support for long-lived token for access and refresh token, by allowing expiresAt to be null. This is often needed for API that delivers an access token that is used to perform API calls, and where this key must not expire.
