### PR TITLE
Allow case-sensitive check for token

### DIFF
--- a/config/doctrine/ZfrOAuth2.Server.Entity.AbstractToken.dcm.xml
+++ b/config/doctrine/ZfrOAuth2.Server.Entity.AbstractToken.dcm.xml
@@ -6,7 +6,11 @@
     http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="ZfrOAuth2\Server\Entity\AbstractToken">
-        <id name="token" type="string" column-definition="VARCHAR(40) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL" />
+        <id name="token" type="string" length="40">
+            <options>
+                <option name="collation">utf8_bin</option>
+            </options>
+        </id>
         <many-to-one field="client" target-entity="ZfrOAuth2\Server\Entity\Client" />
         <many-to-one field="owner" target-entity="ZfrOAuth2\Server\Entity\TokenOwnerInterface" fetch="EAGER">
             <join-column on-delete="CASCADE" />


### PR DESCRIPTION
ping @Ocramius @mac_nibblet

I realized that by default, SQL do case-insenstivie checks for token. This can be an issue as tokens are fetched by the token itself.

I couldn't find anything in Doctrine 2 mapping to force having utf8_bin (which makes case-senstivie checks instead of default utf8_general), so I used a columnDefinition.
