### PR TITLE
Allow multiple redirect uri

### DIFF
--- a/config/doctrine/ZfrOAuth2.Server.Entity.Client.dcm.xml
+++ b/config/doctrine/ZfrOAuth2.Server.Entity.Client.dcm.xml
@@ -12,6 +12,6 @@
         </id>
 
         <field name="secret" type="string" length="60" />
-        <field name="redirectUri" column="redirect_uri" type="string" length="1000" />
+        <field name="redirectUris" column="redirect_uris" type="json_array" />
     </entity>
 </doctrine-mapping>

--- a/src/ZfrOAuth2/Server/Entity/Client.php
+++ b/src/ZfrOAuth2/Server/Entity/Client.php
@@ -50,9 +50,9 @@ class Client
     protected $name;
 
     /**
-     * @var string
+     * @var array
      */
-    protected $redirectUri;
+    protected $redirectUris;
 
     /**
      * Get the client id
@@ -107,24 +107,45 @@ class Client
     }
 
     /**
-     * Set the redirect URI
+     * Set the redirect URIs
      *
-     * @param  string $redirectUri
+     * You can either set a string of comma separated string, or an array
+     *
+     * @param  array|string $redirectUris
      * @return void
      */
-    public function setRedirectUri($redirectUri)
+    public function setRedirectUris($redirectUris)
     {
-        $this->redirectUri = (string) $redirectUri;
+        if (is_string($redirectUris)) {
+            $redirectUris = explode(',', str_replace(' ', '', $redirectUris));
+        } else {
+            foreach ($redirectUris as &$redirectUri) {
+                $redirectUri = (string) $redirectUri;
+            }
+        }
+
+        $this->redirectUris = $redirectUris;
     }
 
     /**
-     * Get the redirect URI
+     * Get the redirect URIs
      *
      * @return string
      */
-    public function getRedirectUri()
+    public function getRedirectUris()
     {
-        return $this->redirectUri;
+        return $this->redirectUris;
+    }
+
+    /**
+     * Check if the given redirect URI is in the list
+     *
+     * @param  string $redirectUri
+     * @return bool
+     */
+    public function hasRedirectUri($redirectUri)
+    {
+        return in_array($redirectUri, $this->redirectUris, true);
     }
 
     /**

--- a/tests/ZfrOAuth2Test/Server/Entity/ClientTest.php
+++ b/tests/ZfrOAuth2Test/Server/Entity/ClientTest.php
@@ -33,11 +33,11 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $client->setSecret('secret');
         $client->setName('name');
-        $client->setRedirectUri('http://www.example.com');
+        $client->setRedirectUris('http://www.example.com');
 
         $this->assertEquals('secret', $client->getSecret());
         $this->assertEquals('name', $client->getName());
-        $this->assertEquals('http://www.example.com', $client->getRedirectUri());
+        $this->assertEquals('http://www.example.com', $client->getRedirectUris()[0]);
     }
 
     public function testCanCheckPublicClient()
@@ -47,5 +47,32 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $client->setSecret('secret');
         $this->assertFalse($client->isPublic());
+    }
+
+    public function testRedirectUri()
+    {
+        $client = new Client();
+        $client->setRedirectUris('http://www.example.com');
+        $this->assertCount(1, $client->getRedirectUris());
+        $this->assertTrue($client->hasRedirectUri('http://www.example.com'));
+        $this->assertFalse($client->hasRedirectUri('http://www.example2.com'));
+
+        $client->setRedirectUris('http://www.example1.com,http://www.example2.com');
+        $this->assertCount(2, $client->getRedirectUris());
+        $this->assertTrue($client->hasRedirectUri('http://www.example1.com'));
+        $this->assertTrue($client->hasRedirectUri('http://www.example2.com'));
+        $this->assertFalse($client->hasRedirectUri('http://www.example3.com'));
+
+        $client->setRedirectUris('http://www.example1.com, http://www.example2.com');
+        $this->assertCount(2, $client->getRedirectUris());
+
+        $this->assertTrue($client->hasRedirectUri('http://www.example1.com'));
+        $this->assertTrue($client->hasRedirectUri('http://www.example2.com'));
+        $this->assertFalse($client->hasRedirectUri('http://www.example3.com'));
+
+        $client->setRedirectUris(['http://www.example.com']);
+        $this->assertCount(1, $client->getRedirectUris());
+        $this->assertTrue($client->hasRedirectUri('http://www.example.com'));
+        $this->assertFalse($client->hasRedirectUri('http://www.example2.com'));
     }
 }


### PR DESCRIPTION
Before doing the HHVM fix, I'm going to merge that quickly. Basically, this allows to have multiple redirect URI in the client which is often useful, but above everything else, it fixes a security issue (disclaimer: I was actually implementing the spec but that's a side effect that can happen).

Previously, if someone was giving a redirect URI in a query param, the user would be redirected to it without check, so that someone making a fake "registration page" could potentially set his own redirect URI. Now, there is a strict check of the given redirect URI and if it was not registered with the client, then an error is thrown instead of generating the auth code.

I'm going to tag this as 0.4 as there is a slight DB model change.

@Ocramius , please could you add a note in the security Symfony thing to encourage people using 0.4 ? (the other grants have no problem, however).
