### PR TITLE
Refresh token grant not allowed to public clients

### DIFF
--- a/src/ZfrOAuth2/Server/Grant/RefreshTokenGrant.php
+++ b/src/ZfrOAuth2/Server/Grant/RefreshTokenGrant.php
@@ -135,6 +135,6 @@ class RefreshTokenGrant extends AbstractGrant
      */
     public function allowPublicClients()
     {
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
According to the spec, refresh token grant is not allowed to public clients. See http://tools.ietf.org/html/rfc6749#section-1.5 and http://stackoverflow.com/questions/3487991/why-does-oauth-v2-have-both-access-and-refresh-tokens

If somebody is already using this grant, I think they are in big trouble.
