### PR TITLE
Trigger exception if invalid token

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please note that until I reach 1.0, I **WILL NOT** follow semantic version. This
 Installation is only officially supported using Composer:
 
 ```sh
-php composer.phar require zfr/zfr-oauth2-server:0.5.*
+php composer.phar require zfr/zfr-oauth2-server:0.6.*
 ```
 
 ## Framework integration

--- a/src/ZfrOAuth2/Server/ResourceServer.php
+++ b/src/ZfrOAuth2/Server/ResourceServer.php
@@ -70,7 +70,7 @@ class ResourceServer
         $token = $this->accessTokenService->getToken($token);
 
         if ($token === null || !$this->isTokenValid($token, $scopes)) {
-            throw new InvalidAccessTokenException();
+            throw new InvalidAccessTokenException('Access token has expired or has been deleted');
         }
 
         return $token;


### PR DESCRIPTION
Previously, ZfrOAuth2 used to trigger an InvalidAccessTokenException if no token could be found in the request. However, if a token was expired or not found in database, it used to do nothing.

The logic is actually wrong: ZfrOAuth2 should instead throw this exception ONLY if a token is given BUT is expired, does not match scope or does not exist anymore.