### PR TITLE
No immutabledatetime

### DIFF
--- a/src/Model/AbstractToken.php
+++ b/src/Model/AbstractToken.php
@@ -19,7 +19,7 @@
 namespace ZfrOAuth2\Server\Model;
 
 use DateTime;
-use DateTimeImmutable;
+use DateTimeInterface;
 
 /**
  * Provide basic functionality for both access tokens, refresh tokens and authorization codes
@@ -48,7 +48,7 @@ abstract class AbstractToken
     private $owner;
 
     /**
-     * @var DateTimeImmutable
+     * @var DateTime
      */
     protected $expiresAt;
 
@@ -99,7 +99,7 @@ abstract class AbstractToken
         $token->owner     = $owner;
         $token->client    = $client;
         $token->scopes    = $scopes ?? [];
-        $token->expiresAt = $ttl ? (new DateTimeImmutable())->modify("+$ttl seconds") : null;
+        $token->expiresAt = $ttl ? (new DateTime())->modify("+$ttl seconds") : null;
 
         return $token;
     }
@@ -154,7 +154,7 @@ abstract class AbstractToken
     /**
      * Get when this token should expire
      *
-     * @return DateTimeImmutable|null
+     * @return DateTimeInterface|null
      */
     public function getExpiresAt()
     {

--- a/src/Model/AbstractToken.php
+++ b/src/Model/AbstractToken.php
@@ -48,7 +48,7 @@ abstract class AbstractToken
     private $owner;
 
     /**
-     * @var DateTime
+     * @var DateTimeInterface
      */
     protected $expiresAt;
 

--- a/tests/src/Model/AccessTokenTest.php
+++ b/tests/src/Model/AccessTokenTest.php
@@ -18,6 +18,8 @@
 
 namespace ZfrOAuth2Test\Server\Model;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use ZfrOAuth2\Server\Model\AccessToken;
 use ZfrOAuth2\Server\Model\Client;
 use ZfrOAuth2\Server\Model\Scope;
@@ -39,7 +41,7 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
         /** @var AccessToken $accessToken */
         $accessToken = AccessToken::createNewAccessToken($ttl, $owner, $client, $scopes);
 
-        $expiresAt = (new \DateTimeImmutable())->modify("+$ttl seconds");
+        $expiresAt = (new DateTimeImmutable())->modify("+$ttl seconds");
 
         $this->assertNotEmpty($accessToken->getToken());
         $this->assertEquals(40, strlen($accessToken->getToken()));
@@ -81,8 +83,8 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($data['owner'], $accessToken->getOwner());
         $this->assertSame($data['client'], $accessToken->getClient());
 
-        if ($data['expiresAt'] instanceof \DateTimeImmutable) {
-            /** @var \DateTimeImmutable $expiresAt */
+        if ($data['expiresAt'] instanceof DateTimeInterface) {
+            /** @var DateTimeInterface $expiresAt */
             $expiresAt = $data['expiresAt'];
             $this->assertSame($expiresAt->getTimeStamp(), $accessToken->getExpiresAt()->getTimestamp());
         } else {
@@ -100,7 +102,7 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
                     'token'     => 'token',
                     'owner'     => $this->getMock(TokenOwnerInterface::class),
                     'client'    => $this->getMock(Client::class, [], [], '', false),
-                    'expiresAt' => new \DateTimeImmutable(),
+                    'expiresAt' => new DateTimeImmutable(),
                     'scopes'    => ['scope1', 'scope2'],
                 ]
             ],


### PR DESCRIPTION
Due to issues with Doctrine and the fact a regular DateTime isn't uses no risks of being mutated any way I propose to revert the DateTimeImmutable expiresAt property to a regular DateTime object.

https://github.com/zf-fr/zfr-oauth2-server-doctrine/issues/6