### PR TITLE
Pass owner to auth server

### DIFF
--- a/config/config.global.php
+++ b/config/config.global.php
@@ -45,5 +45,11 @@ return [
          * password grant
          */
         'owner_callable'         => null,
+
+        /**
+         * Attribute that the AuthorizationRequestMiddleware expects the ZfrOAuth2\Server\Model\TokenOwnerInterface
+         * to be present on
+         */
+        'owner_request_attribute' => 'owner',
     ],
 ];

--- a/src/Container/AuthorizationRequestMiddlewareFactory.php
+++ b/src/Container/AuthorizationRequestMiddlewareFactory.php
@@ -24,6 +24,7 @@ namespace ZfrOAuth2\Server\Container;
 use Interop\Container\ContainerInterface;
 use ZfrOAuth2\Server\AuthorizationServerInterface;
 use ZfrOAuth2\Server\Middleware\AuthorizationRequestMiddleware;
+use ZfrOAuth2\Server\Options\ServerOptions;
 
 /**
  * @author  Michaël Gallego <mic.gallego@gmail.com>
@@ -35,7 +36,9 @@ class AuthorizationRequestMiddlewareFactory
     {
         /** @var AuthorizationServerInterface $authorizationServer */
         $authorizationServer = $container->get(AuthorizationServerInterface::class);
+        /** @var ServerOptions $serverOptions */
+        $serverOptions       = $container->get(ServerOptions::class);
 
-        return new AuthorizationRequestMiddleware($authorizationServer);
+        return new AuthorizationRequestMiddleware($authorizationServer, $serverOptions);
     }
 }

--- a/src/Middleware/AuthorizationRequestMiddleware.php
+++ b/src/Middleware/AuthorizationRequestMiddleware.php
@@ -24,6 +24,7 @@ namespace ZfrOAuth2\Server\Middleware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use ZfrOAuth2\Server\AuthorizationServerInterface;
+use ZfrOAuth2\Server\Options\ServerOptions;
 
 /**
  * Authorization request middleware endpoint of the authorization server
@@ -35,9 +36,15 @@ class AuthorizationRequestMiddleware
      */
     private $authorizationServer;
 
-    public function __construct(AuthorizationServerInterface $authorizationServer)
+    /**
+     * @var ServerOptions
+     */
+    private $serverOptions;
+
+    public function __construct(AuthorizationServerInterface $authorizationServer, ServerOptions $serverOptions)
     {
         $this->authorizationServer = $authorizationServer;
+        $this->serverOptions = $serverOptions;
     }
 
     public function __invoke(
@@ -45,6 +52,8 @@ class AuthorizationRequestMiddleware
         ResponseInterface $response,
         callable $next
     ): ResponseInterface {
-        return $this->authorizationServer->handleAuthorizationRequest($request);
+        $owner = $request->getAttribute($this->serverOptions->getOwnerRequestAttribute());
+
+        return $this->authorizationServer->handleAuthorizationRequest($request, $owner);
     }
 }

--- a/src/Options/ServerOptions.php
+++ b/src/Options/ServerOptions.php
@@ -79,6 +79,14 @@ final class ServerOptions
     private $grants = [];
 
     /**
+     * Attribute that the AuthorizationRequestMiddleware expects the ZfrOAuth2\Server\Model\TokenOwnerInterface
+     * to be present on
+     *
+     * @var string
+     */
+    private $ownerRequestAttribute;
+
+    /**
      * @param callable|string $ownerCallable either a callable or the name of a container service
      */
     private function __construct(
@@ -88,7 +96,8 @@ final class ServerOptions
         bool $rotateRefreshTokens,
         bool $revokeRotatedRefreshTokens,
         $ownerCallable,
-        array $grants
+        array $grants,
+        string $ownerRequestAttribute
     ) {
         $this->authorizationCodeTtl       = $authorizationCodeTtl;
         $this->accessTokenTtl             = $accessTokenTtl;
@@ -97,6 +106,7 @@ final class ServerOptions
         $this->revokeRotatedRefreshTokens = $revokeRotatedRefreshTokens;
         $this->ownerCallable              = $ownerCallable;
         $this->grants                     = $grants;
+        $this->ownerRequestAttribute      = $ownerRequestAttribute;
     }
 
     /**
@@ -111,7 +121,8 @@ final class ServerOptions
             $options['rotate_refresh_tokens'] ?? false,
             $options['revoke_rotated_refresh_tokens'] ?? true,
             $options['owner_callable'] ?? null,
-            $options['grants'] ?? []
+            $options['grants'] ?? [],
+            $options['owner_request_attribute'] ?? 'owner'
         );
     }
 
@@ -171,5 +182,14 @@ final class ServerOptions
     public function getGrants(): array
     {
         return $this->grants;
+    }
+
+    /**
+     * Gets attribute that the AuthorizationRequestMiddleware expects the ZfrOAuth2\Server\Model\TokenOwnerInterface
+     * to be present on
+     */
+    public function getOwnerRequestAttribute(): string
+    {
+        return $this->ownerRequestAttribute;
     }
 }

--- a/tests/src/Container/AuthorizationRequestMiddlewareFactoryTest.php
+++ b/tests/src/Container/AuthorizationRequestMiddlewareFactoryTest.php
@@ -22,6 +22,7 @@ use Interop\Container\ContainerInterface;
 use ZfrOAuth2\Server\AuthorizationServerInterface;
 use ZfrOAuth2\Server\Container\AuthorizationRequestMiddlewareFactory;
 use ZfrOAuth2\Server\Middleware\AuthorizationRequestMiddleware;
+use ZfrOAuth2\Server\Options\ServerOptions;
 
 /**
  * @author  Bas Kamer <baskamer@gmail.com>
@@ -38,6 +39,10 @@ class AuthorizationRequestMiddlewareFactoryTest extends \PHPUnit_Framework_TestC
             ->method('get')
             ->with(AuthorizationServerInterface::class)
             ->willReturn($this->createMock(AuthorizationServerInterface::class));
+        $container->expects($this->at(1))
+            ->method('get')
+            ->with(ServerOptions::class)
+            ->willReturn(ServerOptions::fromArray());
 
         $factory = new AuthorizationRequestMiddlewareFactory();
         $service = $factory($container);

--- a/tests/src/Middleware/AuthorizationRequestMiddlewareTest.php
+++ b/tests/src/Middleware/AuthorizationRequestMiddlewareTest.php
@@ -22,6 +22,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface as RequestInterface;
 use ZfrOAuth2\Server\AuthorizationServerInterface;
 use ZfrOAuth2\Server\Middleware\AuthorizationRequestMiddleware;
+use ZfrOAuth2\Server\Options\ServerOptions;
 
 /**
  * @author  Michaël Gallego <mic.gallego@gmail.com>
@@ -33,7 +34,8 @@ class AuthorizationRequestMiddlewareTest extends \PHPUnit_Framework_TestCase
     public function testWillHandleAuthorizationRequest()
     {
         $authorizationServer = $this->createMock(AuthorizationServerInterface::class);
-        $middleware          = new AuthorizationRequestMiddleware($authorizationServer);
+        $serverOptions       = ServerOptions::fromArray();
+        $middleware          = new AuthorizationRequestMiddleware($authorizationServer, $serverOptions);
 
         $request  = $this->createMock(RequestInterface::class);
         $response = $this->createMock(ResponseInterface::class);

--- a/tests/src/Options/ServerOptionsTest.php
+++ b/tests/src/Options/ServerOptionsTest.php
@@ -40,6 +40,7 @@ class ServerOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($options->getGrants());
         $this->assertFalse($options->getRotateRefreshTokens());
         $this->assertTrue($options->getRevokeRotatedRefreshTokens());
+        $this->assertEquals('owner', $options->getOwnerRequestAttribute());
     }
 
     public function testGetters()
@@ -54,7 +55,8 @@ class ServerOptionsTest extends \PHPUnit_Framework_TestCase
             'rotate_refresh_tokens'         => true,
             'revoke_rotated_refresh_tokens' => false,
             'owner_callable'                => $callable,
-            'grants'                        => [ClientCredentialsGrant::class]
+            'grants'                        => [ClientCredentialsGrant::class],
+            'owner_request_attribute'       => 'something'
         ]);
 
         $this->assertEquals(300, $options->getAuthorizationCodeTtl());
@@ -64,5 +66,6 @@ class ServerOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(false, $options->getRevokeRotatedRefreshTokens());
         $this->assertSame($callable, $options->getOwnerCallable());
         $this->assertEquals([ClientCredentialsGrant::class], $options->getGrants());
+        $this->assertEquals('something', $options->getOwnerRequestAttribute());
     }
 }


### PR DESCRIPTION
This PR add a configurable way of getting the owner object into the AuthServerMiddleware

