### PR TITLE
Scopes

### DIFF
--- a/src/Grant/AuthorizationGrant.php
+++ b/src/Grant/AuthorizationGrant.php
@@ -110,10 +110,11 @@ class AuthorizationGrant extends AbstractGrant implements AuthorizationServerAwa
         }
 
         // Scope and state allow to perform additional validation
-        $scope = $queryParams['scope'] ?? null;
-        $state = $queryParams['state'] ?? null;
+        $scope  = $queryParams['scope'] ?? null;
+        $state  = $queryParams['state'] ?? null;
+        $scopes = is_string($scope) ? explode(' ', $scope) : [];
 
-        $authorizationCode = $this->authorizationCodeService->createToken($redirectUri, $owner, $client, $scope);
+        $authorizationCode = $this->authorizationCodeService->createToken($redirectUri, $owner, $client, $scopes);
 
         $uri = http_build_query(array_filter([
             'code'  => $authorizationCode->getToken(),

--- a/src/Grant/ClientCredentialsGrant.php
+++ b/src/Grant/ClientCredentialsGrant.php
@@ -80,10 +80,11 @@ class ClientCredentialsGrant extends AbstractGrant
         $postParams = $request->getParsedBody();
 
         // Everything is okey, we can start tokens generation!
-        $scope = $postParams['scope'] ?? null;
+        $scope  = $postParams['scope'] ?? null;
+        $scopes = is_string($scope) ? explode(' ', $scope) : [];
 
         /** @var AccessToken $accessToken */
-        $accessToken = $this->accessTokenService->createToken($owner, $client, $scope);
+        $accessToken = $this->accessTokenService->createToken($owner, $client, $scopes);
 
         return $this->prepareTokenResponse($accessToken);
     }

--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -111,6 +111,7 @@ class PasswordGrant extends AbstractGrant implements AuthorizationServerAwareInt
         $username = $postParams['username'] ?? null;
         $password = $postParams['password'] ?? null;
         $scope    = $postParams['scope'] ?? null;
+        $scopes   = is_string($scope) ? explode(' ', $scope) : [];
 
         if (null === $username || null === $password) {
             throw OAuth2Exception::invalidRequest('Username and/or password is missing');
@@ -124,13 +125,13 @@ class PasswordGrant extends AbstractGrant implements AuthorizationServerAwareInt
         }
 
         // Everything is okay, we can start tokens generation!
-        $accessToken = $this->accessTokenService->createToken($owner, $client, $scope);
+        $accessToken = $this->accessTokenService->createToken($owner, $client, $scopes);
 
         // Before generating a refresh token, we must make sure the authorization server supports this grant
         $refreshToken = null;
 
         if ($this->authorizationServer->hasGrant(RefreshTokenGrant::GRANT_TYPE)) {
-            $refreshToken = $this->refreshTokenService->createToken($owner, $client, $scope);
+            $refreshToken = $this->refreshTokenService->createToken($owner, $client, $scopes);
         }
 
         return $this->prepareTokenResponse($accessToken, $refreshToken);

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -103,7 +103,8 @@ class RefreshTokenGrant extends AbstractGrant
         // We can now create a new access token! First, we need to make some checks on the asked scopes,
         // because according to the spec, a refresh token can create an access token with an equal or lesser
         // scope, but not more
-        $scopes = $postParams['scope'] ?? $refreshToken->getScopes();
+        $scope  = $postParams['scope'] ?? null;
+        $scopes = is_string($scope) ? explode(' ', $scope) : $refreshToken->getScopes();
 
         if (! $refreshToken->matchScopes($scopes)) {
             throw OAuth2Exception::invalidScope(

--- a/src/Model/AbstractToken.php
+++ b/src/Model/AbstractToken.php
@@ -70,30 +70,22 @@ abstract class AbstractToken
     /**
      * Create a new AbstractToken
      *
-     * @param int                          $ttl
-     * @param TokenOwnerInterface          $owner
-     * @param Client                       $client
-     * @param string|string[]|Scope[]|null $scopes
+     * @param int                   $ttl
+     * @param TokenOwnerInterface   $owner
+     * @param Client                $client
+     * @param string[]|Scope[]|null $scopes
      * @return AbstractToken
      */
     protected static function createNew(
         int $ttl,
         TokenOwnerInterface $owner = null,
         Client $client = null,
-        $scopes = null
+        array $scopes = null
     ): self {
-        if (isset($scopes) && $scopes instanceof Scope) {
-            $scopes = $scopes->getName();
-        }
-
-        if (is_string($scopes)) {
-            $scopes = explode(' ', $scopes);
-        }
-
         if (is_array($scopes)) {
-            foreach ($scopes as &$scope) {
-                $scope = $scope instanceof Scope ? $scope->getName() : (string) $scope;
-            }
+            $scopes = array_map(function ($scope) {
+                return (string) $scope;
+            }, $scopes);
         }
 
         $token = new static();

--- a/src/Model/Scope.php
+++ b/src/Model/Scope.php
@@ -120,4 +120,9 @@ class Scope
     {
         return $this->isDefault;
     }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
 }

--- a/src/Service/AbstractTokenService.php
+++ b/src/Service/AbstractTokenService.php
@@ -23,6 +23,7 @@ namespace ZfrOAuth2\Server\Service;
 
 use ZfrOAuth2\Server\Exception\OAuth2Exception;
 use ZfrOAuth2\Server\Model\AbstractToken;
+use ZfrOAuth2\Server\Model\Scope;
 use ZfrOAuth2\Server\Options\ServerOptions;
 use ZfrOAuth2\Server\Repository\TokenRepositoryInterface;
 
@@ -95,17 +96,21 @@ abstract class AbstractTokenService
     /**
      * Validate the token scopes against the registered scope
      *
-     * @param  array $scopes
+     * @param string[]|Scope[] $scopes
      *
      * @throws OAuth2Exception (invalid_scope) When one or more of the given scopes where not registered
      */
     protected function validateTokenScopes(array $scopes)
     {
+        $scopes = array_map(function ($scope) {
+            return (string) $scope;
+        }, $scopes);
+
         $registeredScopes = $this->scopeService->getAll();
 
-        foreach ($registeredScopes as &$registeredScope) {
-            $registeredScope = is_string($registeredScope) ? $registeredScope : $registeredScope->getName();
-        }
+        $registeredScopes = array_map(function ($scope) {
+            return (string) $scope;
+        }, $registeredScopes);
 
         $diff = array_diff($scopes, $registeredScopes);
 

--- a/src/Service/AccessTokenService.php
+++ b/src/Service/AccessTokenService.php
@@ -44,13 +44,13 @@ class AccessTokenService extends AbstractTokenService
     /**
      * Create a new token (and generate the token)
      *
-     * @param TokenOwnerInterface     $owner
-     * @param Client                  $client
-     * @param string|string[]|Scope[] $scopes
+     * @param TokenOwnerInterface $owner
+     * @param Client              $client
+     * @param string[]|Scope[]    $scopes
      * @return AccessToken
      * @throws OAuth2Exception
      */
-    public function createToken($owner, $client, $scopes): AccessToken
+    public function createToken($owner, $client, array $scopes = []): AccessToken
     {
         if (empty($scopes)) {
             $scopes = $this->scopeService->getDefaultScopes();

--- a/src/Service/AuthorizationCodeService.php
+++ b/src/Service/AuthorizationCodeService.php
@@ -44,14 +44,14 @@ class AuthorizationCodeService extends AbstractTokenService
     /**
      * Create a new token (and generate the token)
      *
-     * @param string                  $redirectUri
-     * @param TokenOwnerInterface     $owner
-     * @param Client                  $client
-     * @param string|string[]|Scope[] $scopes
+     * @param string              $redirectUri
+     * @param TokenOwnerInterface $owner
+     * @param Client              $client
+     * @param string[]|Scope[]    $scopes
      * @return AuthorizationCode
      * @throws OAuth2Exception
      */
-    public function createToken($redirectUri, $owner, $client, $scopes): AuthorizationCode
+    public function createToken($redirectUri, $owner, $client, array $scopes = []): AuthorizationCode
     {
         if (empty($scopes)) {
             $scopes = $this->scopeService->getDefaultScopes();

--- a/src/Service/RefreshTokenService.php
+++ b/src/Service/RefreshTokenService.php
@@ -44,13 +44,13 @@ class RefreshTokenService extends AbstractTokenService
     /**
      * Create a new token (and generate the token)
      *
-     * @param TokenOwnerInterface     $owner
-     * @param Client                  $client
-     * @param string|string[]|Scope[] $scopes
+     * @param TokenOwnerInterface $owner
+     * @param Client              $client
+     * @param string[]|Scope[]    $scopes
      * @return RefreshToken
      * @throws OAuth2Exception
      */
-    public function createToken($owner, $client, $scopes): RefreshToken
+    public function createToken($owner, $client, array $scopes = []): RefreshToken
     {
         if (empty($scopes)) {
             $scopes = $this->scopeService->getDefaultScopes();

--- a/tests/src/Model/AccessTokenTest.php
+++ b/tests/src/Model/AccessTokenTest.php
@@ -76,7 +76,7 @@ class AccessTokenTest extends TestCase
                 3600,
                 $this->createMock(TokenOwnerInterface::class),
                 $this->createMock(Client::class),
-                Scope::createNewScope(1, 'read'),
+                [Scope::createNewScope(1, 'read')],
             ],
             [3600, null, null, null],
             [0, null, null, null],
@@ -153,13 +153,13 @@ class AccessTokenTest extends TestCase
 
     public function testIsValid()
     {
-        $accessToken = AccessToken::createNewAccessToken(60, null, null, 'read write');
+        $accessToken = AccessToken::createNewAccessToken(60, null, null, ['read', 'write']);
         $this->assertTrue($accessToken->isValid('read'));
 
-        $accessToken = AccessToken::createNewAccessToken(-60, null, null, 'read write');
+        $accessToken = AccessToken::createNewAccessToken(-60, null, null, ['read', 'write']);
         $this->assertFalse($accessToken->isValid('read'));
 
-        $accessToken = AccessToken::createNewAccessToken(60, null, null, 'read write');
+        $accessToken = AccessToken::createNewAccessToken(60, null, null, ['read', 'write']);
         $this->assertFalse($accessToken->isValid('delete'));
     }
 }

--- a/tests/src/Model/AuthorizationCodeTest.php
+++ b/tests/src/Model/AuthorizationCodeTest.php
@@ -116,13 +116,13 @@ class AuthorizationCodeTest extends TestCase
 
     public function testIsValid()
     {
-        $authorizationCode = AuthorizationCode::createNewAuthorizationCode(60, 'http://www.example.com', null, null, 'read write');
+        $authorizationCode = AuthorizationCode::createNewAuthorizationCode(60, 'http://www.example.com', null, null, ['read', 'write']);
         $this->assertTrue($authorizationCode->isValid('read'));
 
-        $authorizationCode = AuthorizationCode::createNewAuthorizationCode(-60, 'http://www.example.com', null, null, 'read write');
+        $authorizationCode = AuthorizationCode::createNewAuthorizationCode(-60, 'http://www.example.com', null, null, ['read', 'write']);
         $this->assertFalse($authorizationCode->isValid('read'));
 
-        $authorizationCode = AuthorizationCode::createNewAuthorizationCode(60, 'http://www.example.com', null, null, 'read write');
+        $authorizationCode = AuthorizationCode::createNewAuthorizationCode(60, 'http://www.example.com', null, null, ['read', 'write']);
         $this->assertFalse($authorizationCode->isValid('delete'));
     }
 
@@ -131,7 +131,7 @@ class AuthorizationCodeTest extends TestCase
      */
     public function testDoNotSupportLongLiveToken()
     {
-        $authorizationCode = AuthorizationCode::createNewAuthorizationCode(0, 'http://www.example.com', null, null, 'read write');
+        $authorizationCode = AuthorizationCode::createNewAuthorizationCode(0, 'http://www.example.com', null, null, ['read', 'write']);
         $this->assertTrue($authorizationCode->isExpired());
     }
 }

--- a/tests/src/Model/RefreshTokenTest.php
+++ b/tests/src/Model/RefreshTokenTest.php
@@ -74,7 +74,7 @@ class RefreshTokenTest extends TestCase
                 3600,
                 $this->createMock(TokenOwnerInterface::class),
                 $this->createMock(Client::class),
-                'scope1',
+                ['scope1'],
             ],
             [3600, null, null, null],
             [0, null, null, null],
@@ -151,13 +151,13 @@ class RefreshTokenTest extends TestCase
 
     public function testIsValid()
     {
-        $accessToken = RefreshToken::createNewRefreshToken(60, null, null, 'read write');
+        $accessToken = RefreshToken::createNewRefreshToken(60, null, null, ['read', 'write']);
         $this->assertTrue($accessToken->isValid('read'));
 
-        $accessToken = RefreshToken::createNewRefreshToken(-60, null, null, 'read write');
+        $accessToken = RefreshToken::createNewRefreshToken(-60, null, null, ['read', 'write']);
         $this->assertFalse($accessToken->isValid('read'));
 
-        $accessToken = RefreshToken::createNewRefreshToken(60, null, null, 'read write');
+        $accessToken = RefreshToken::createNewRefreshToken(60, null, null, ['read', 'write']);
         $this->assertFalse($accessToken->isValid('delete'));
     }
 }

--- a/tests/src/Model/ScopeTest.php
+++ b/tests/src/Model/ScopeTest.php
@@ -74,4 +74,11 @@ class ScopeTest extends TestCase
             ],
         ];
     }
+
+    public function testToString()
+    {
+        $scope = Scope::createNewScope(1, 'name', 'description');
+
+        $this->assertEquals('name', (string) $scope);
+    }
 }

--- a/tests/src/ResourceServerTest.php
+++ b/tests/src/ResourceServerTest.php
@@ -143,7 +143,8 @@ class ResourceServerTest extends TestCase
      */
     public function testCanValidateAccessToResource($expiredToken, $tokenScope, $desiredScope, $match)
     {
-        $request = $this->createMock(ServerRequestInterface::class);
+        $tokenScope = explode(' ', $tokenScope);
+        $request    = $this->createMock(ServerRequestInterface::class);
         $request->expects($this->once())->method('hasHeader')->with('Authorization')->will($this->returnValue(true));
         $request->expects($this->once())->method('getHeaderLine')->will($this->returnValue('Bearer token'));
 


### PR DESCRIPTION
This PR fixes a bug where requesting tokens with a scope would fail due to incorrect arguments

Additionally; I've limited the scope arguments to arrays with strings or Scope's and changed the method used Scope to strings are handled via an array_map (string) call