### PR TITLE
Invalid token error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## dev-master
+
+* When an token can't be found the returned error response by the resource server middleware is now in a similar format to other errors. This might BC if your client depends on the error key in the message.
+
 ## v0.8.0-beta1
 
 BC! Pre release of a completely rewritten library. It focusses on core OAuth2 functionality and has been decoupled from persistence. If you still need the previous implementation - which is considered EOL - see the [legacy-0.7](https://github.com/zf-fr/zfr-oauth2-server/tree/legacy-0.7) branch

--- a/src/Exception/InvalidAccessTokenException.php
+++ b/src/Exception/InvalidAccessTokenException.php
@@ -25,8 +25,22 @@ use InvalidArgumentException;
 
 /**
  * @author  Michaël Gallego <mic.gallego@gmail.com>
+ * @author  Bas Kamer <baskamer@gmail.com>
  * @licence MIT
  */
 class InvalidAccessTokenException extends InvalidArgumentException implements ExceptionInterface
 {
+    /**
+     * Override the constructor to allow $code as a string
+     */
+    public function __construct(string $message, string $code)
+    {
+        $this->message = (string) $message;
+        $this->code    = (string) $code;
+    }
+
+    public static function invalidToken(string $description): InvalidAccessTokenException
+    {
+        return new self($description, 'invalid_token');
+    }
 }

--- a/src/Middleware/ResourceServerMiddleware.php
+++ b/src/Middleware/ResourceServerMiddleware.php
@@ -61,7 +61,7 @@ class ResourceServerMiddleware
         } catch (InvalidAccessTokenException $exception) {
             // If we're here, this means that there was an access token, but it's either expired or invalid. If
             // that's the case we must immediately return
-            return new JsonResponse(['error' => $exception->getMessage()], 401);
+            return new JsonResponse(['error' => $exception->getCode(), 'error_description' => $exception->getMessage()], 401);
         }
 
         // Otherwise, if we actually have a token and set it as part of the request attribute for next step

--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -70,7 +70,7 @@ class ResourceServer implements ResourceServerInterface
         $token = $this->accessTokenService->getToken($token);
 
         if ($token === null || ! $token->isValid($scopes)) {
-            throw new InvalidAccessTokenException('Access token has expired or has been deleted');
+            throw InvalidAccessTokenException::invalidToken('Access token has expired or has been deleted');
         }
 
         return $token;

--- a/tests/src/Exception/InvalidAccessTokenExceptionTest.php
+++ b/tests/src/Exception/InvalidAccessTokenExceptionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrOAuth2Test\Server\Exception;
+
+use PHPUnit\Framework\TestCase;
+use ZfrOAuth2\Server\Exception\InvalidAccessTokenException;
+
+/**
+ * @author  Bas Kamer <baskamer@gmail.com>
+ * @licence MIT
+ * @covers  \ZfrOAuth2\Server\Exception\InvalidAccessTokenException
+ */
+class InvalidAccessTokenExceptionTest extends TestCase
+{
+    /**
+     * @dataProvider dataproviderErrorsCode
+     */
+    public function testErrorsCode($errorName, $expectedErrorCode)
+    {
+        $exception = InvalidAccessTokenException::$errorName('description');
+
+        $this->assertInstanceOf(InvalidAccessTokenException::class, $exception);
+        $this->assertSame('description', $exception->getMessage());
+        $this->assertSame($expectedErrorCode, $exception->getCode());
+    }
+
+    public function dataproviderErrorsCode()
+    {
+        return [
+            ['invalidToken', 'invalid_token'],
+        ];
+    }
+}

--- a/tests/src/Middleware/ResourceServerMiddlewareTest.php
+++ b/tests/src/Middleware/ResourceServerMiddlewareTest.php
@@ -92,14 +92,13 @@ class ResourceServerMiddlewareTest extends TestCase
     {
         $resourceServer = $this->createMock(ResourceServer::class);
         $middleware     = new ResourceServerMiddleware($resourceServer);
-        $accessToken    = null;
         $request        = $this->createMock(RequestInterface::class);
         $response       = $this->createMock(ResponseInterface::class);
 
         $resourceServer->expects($this->once())
             ->method('getAccessToken')
             ->with($request)
-            ->willThrowException(new InvalidAccessTokenException('error message'));
+            ->willThrowException(InvalidAccessTokenException::invalidToken('error message'));
 
         $result = $middleware($request, $response, function ($request, $response) {
             return $response;
@@ -108,6 +107,6 @@ class ResourceServerMiddlewareTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $result);
 
         $this->assertSame(401, $result->getStatusCode());
-        $this->assertSame('{"error":"error message"}', (string) $result->getBody());
+        $this->assertSame('{"error":"invalid_token","error_description":"error message"}', (string) $result->getBody());
     }
 }


### PR DESCRIPTION
returned payload by resource middleware is now

`{"error" : "invalid_token", "error_description": "Access token has expired or has been deleted"}`

instead of

`{"error": "Access token has expired or has been deleted"}`

Resource server still returns an InvalidAccessTokenException but now has a string code of `invalid_token`